### PR TITLE
Fix DLT pipeline run_as configuration error

### DIFF
--- a/databricks.yml
+++ b/databricks.yml
@@ -26,5 +26,9 @@ targets:
       # CD workflow sets these from secrets DATABRICKS_PROD_HOST and DATABRICKS_PROD_TOKEN
       root_path: /Workspace/Shared/prod/.bundle/${bundle.name}/${bundle.target}
     
-    run_as:
-      service_principal_name: ${DATABRICKS_SERVICE_PRINCIPAL_NAME}
+    # Apply run_as only to jobs (not pipelines)
+    resources:
+      jobs:
+        test_databricks_asset_bundles_job:
+          run_as:
+            service_principal_name: ${DATABRICKS_SERVICE_PRINCIPAL_NAME}


### PR DESCRIPTION
- Move run_as from target level to job-specific configuration
- Pipelines don't support run_as and must be owned by authenticated user
- Use target-specific resource configuration for service principal
- Resolves: 'pipelines do not support a setting a run_as user' error

Only jobs will use service principal authentication, pipelines will use the authenticated user (which is correct behavior for DLT).