### PR TITLE
docs: explain group-based permissions approach and remove service pri…

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -42,7 +42,6 @@ jobs:
             DATABRICKS_HOST: ${{ secrets.DATABRICKS_PROD_HOST }}
             DATABRICKS_CLIENT_ID: ${{ secrets.DATABRICKS_CLIENT_ID }}
             DATABRICKS_CLIENT_SECRET: ${{ secrets.DATABRICKS_CLIENT_SECRET }}
-            DATABRICKS_SERVICE_PRINCIPAL_NAME: ${{ secrets.DATABRICKS_SERVICE_PRINCIPAL_NAME }}
           run: |
             # Validate the bundle configuration before deployment
             databricks bundle validate --target prod

--- a/databricks.yml
+++ b/databricks.yml
@@ -4,13 +4,6 @@ bundle:
   name: test_databricks_asset_bundles
   uuid: da3439c8-68ba-48bd-bcaa-af8f4ee4ad34
 
-variables:
-  service_principal_name:
-    description: "Service principal name for production deployment permissions"
-    # This will be set via environment variable DATABRICKS_SERVICE_PRINCIPAL_NAME in CI/CD
-    # For local testing, defaults to a placeholder that can be overridden
-    default: "databricks-cicd-sp"
-
 include:
   - resources/*.yml
   - resources/*/*.yml
@@ -36,9 +29,5 @@ targets:
     
     # Set proper permissions for the shared workspace
     permissions:
-      # Explicitly include the deployment service principal for CAN_MANAGE permissions
-      - service_principal_name: ${var.service_principal_name}
-        level: CAN_MANAGE
-      # Also include users group for broader access
       - level: CAN_MANAGE
         group_name: users


### PR DESCRIPTION
…ncipal name dependency

- Remove DATABRICKS_SERVICE_PRINCIPAL_NAME from CD workflow (not needed)
- Update README with comprehensive explanation of group-based vs explicit permissions
- Explain why CLI permission recommendations can be safely ignored
- Document benefits of group-based approach: flexibility, maintainability, no hardcoded names
- Add troubleshooting section about CLI permission warnings
- Keep simple group-based permissions in databricks.yml (users group)